### PR TITLE
use mathematical notation

### DIFF
--- a/MonkeySub Paragon/README.md
+++ b/MonkeySub Paragon/README.md
@@ -6,82 +6,88 @@ Name of the Paragon : USS Seawolf-575
 
 In game description: "After YEARS of making, I finally succeeded to create the perfect radioactive destroyer. It can destroy anything! Even... Oh no... I forgot about DDTs... - Dr. Monkey"
 
-Details about the Paragon:
+Stats for nerds (__let x be the Paragon Degree__):
 ```
-Range: 90
-Cost: 450,000
+range(_): 90 units
+cost(_): $450,000
 ```
 
 Base Darts Projectile (005 Sub's Darts):
 ```
-All degrees
-Damage = degree / 10 + 16
-Rate = -0.00003 * (degree - 1) + 0.03
+1..49:
+    speed(_) = 300
+    damage(x) = ⌊x / 10⌋ + 16
+   speed(x) = -0.00003(x - 1) + 0.03
 
-From degree 1 to 49
-Speed = 300
-
-From degree 50
-Speed = 6.5f * degree;
+50..100:
+    speed(x) = 6.5x
+    damage(x) = x / 10 + 16
+   speed(x) = -0.00003(x - 1) + 0.03
 ```
 
 Fraction Projectile (005 Sub's Darts' Projectile)
 ```
-All degrees
-Speed = 900
+1..24:
+     speed(_) = 900
+    damage(_) = 8
+     count(_) = 7
 
-From degree 1 to 24
-Count = 7
-Damage = 8
+25..74:
+     speed(_) = 900
+    damage(x) = x / 8 + 8
+     count(_) = 9
 
-Upon degree 25
-Damage = degree / 8 + 8
-
-From degree 25 to 74
-Count = 9
-
-Upon degree 75
-Count = 13
+75..100:
+     speed(_) = 900
+    damage(x) = x / 8 + 8
+     count(_) = 13
 ```
 
-Big Missile
+Big Missile (missing areas)
 ```
-From degree 1 to 74
-Rate = 5 / 7 * degree + 10;
+1..49:
+    damage(_) = 20,000
+     speed(x) = (5/7)x + 10
+     count(_) = ???
 
-From degree 1 to 49
-Damage = 20000
+50..74:
+    damage(_) = ???
+     speed(_) = ???
+     count(_) = ???
 
-From degree 75 to 99
-Rate = 60
+75..99:
+    damage(_) = ???
+     speed(_) = 60
+     count(_) = ???
 
-From degree 100
-Rate = 20
+100:
+    damage(_) = ???
+     speed(_) = 20
+     count(_) = ???
 ```
 
 Normal Missile
 ```
-All degrees
-Damage = 2000 * (degree / 10 + 1)
-Note that (degree / 10 + 1) can only be an integer
-Rate = 0.5
+1..100:
+    damage(x) = 2000(⌊x / 10⌋ + 1)
+     speed(_) = 0.5
 ```
 
 Radioactive Zone
 ```
-All degrees
-Damage = 500
+1..49:
+      damage(_) = 500
+    interval(_) = 0.1
+    lifespan(_) = 20
 
-From degree 1 to 49
-Interval = 0.1
-Lifespan = 20
-
-Upon degree 50
-Interval = 0.05
-Lifespan = 0.4 * degree + 20
+50..100:
+      damage(_) = 500
+    interval(_) = 0.05
+    lifespan(x) = 0.4x + 20
 ```
 
 Pre Emptive Strike
 ```
-Damage = 1500
+1..100:
+    damage(_) = 1500
 ```

--- a/VillageParagon/Sentries/README.md
+++ b/VillageParagon/Sentries/README.md
@@ -1,42 +1,12 @@
 Here is the informations about each sentry.
 
-# What is tier5Counts[x] ?
-Like vanilla Paragons, the Village paragon increases in power the higher its degree is. But in order to fully get access to this power increase, you must sacrifice 5 T5 towers of each type. **Not every sacrifice buff every sentry**. Here is which tower type buffs which sentry with the ID:
+# What is S, B, G, and F?
+Like vanilla Paragons, the Village paragon increases in power the higher its degree is. But in order to fully get access to this power increase, you must sacrifice 5 T5 towers of each type. **Not every sacrifice buff every sentry**. Here is which tower type buffs which sentry with the variable name:
 ```
-(0) Primary -> Solver Sentry
-(1) Military -> Big Boi Sentry
-(2) Magic -> Group Sentry
-(3) Support -> Farming Sentry
-```
-So tier5Counts[x] is equal to the number of sacrificed towers of the associated type (x = 3 for the Farming Sentry).
-
-# Farming Sentry ![Farming Sentry Picture](farming_sentry.png)
-Description: 
-```
-Spawn a money geyser for 5 seconds. 
-The sentry is spawned every 60 seconds.
-
-Value of the crates = 625 + 625 * degree / 100 * tier5Counts[3] / 5
-Rate = 0.05
-```
-
-# Big Boi Sentry ![Big Boi Sentry Picture](big_boi_sentry.PNG)
-```
-Deals huge single target damage for 120 seconds.
-The sentry is spawned every 30 seconds.
-
-Rate = 0.15f - degree / 1000f
-Damage = 240 + Math.FloorToInt(960f * degree / 1000f) * 10 * tier5Counts[1] / 5
-```
-
-# Group Sentry ![Group Picture](group_sentry.PNG)
-```
-Deals huge multi target damage for 60 seconds.
-The sentry is spawned every 60 seconds.
-
-Ability cooldown = 15 - 10 * degree / 100 * tier5Counts[2] / 5
-Damage = 4 + 12 * degree / 100 * tier5Counts[2] / 5
-Pierce = 18 + 54 * degree / 100 * tier5Counts[2] / 5
+Primary Sacrifice -> Solver Sentry (s)
+Military Sacrifice -> Big Boi Sentry (b)
+Magic Sacrifice -> Group Sentry (g)
+Support Sacrifice -> Farming Sentry (f)
 ```
 
 # Solver Sentry ![Solver Picture](solver_sentry.PNG)
@@ -44,9 +14,38 @@ Pierce = 18 + 54 * degree / 100 * tier5Counts[2] / 5
 Deals slow bloons for 60 seconds.
 The sentry is spawned every 60 seconds.
 
-Rate = 0.15f - 0.1f * degree / 100 * tier5Counts[0] / 5
-Slow Moab Multiplier = 4  + 2 * degree / 100 * tier5Counts[3] / 5
-Slow BFB Multiplier = 0.2f + 0.4f * degree / 100 * tier5Counts[3] / 5
-Slow ZOMG Multiplier = 0.4f + 0.8f * degree / 100 * tier5Counts[3] / 5
-Slow BAD Multiplier = 3f + 3f * degree / 100 * tier5Counts[3] / 5
+     speed(x) = 0.15 - 0.001(sx)
+moab_speed(x) = 4    + sx / 150
+ bfb_speed(x) = 0.2  + 0.0008(sx)
+zomg_speed(x) = 0.4  + 0.0016(sx)
+ bad_speed(x) = 3    + 0.006(sx)
+```
+
+# Big Boi Sentry ![Big Boi Sentry Picture](big_boi_sentry.PNG)
+```
+Deals huge single target damage for 120 seconds.
+The sentry is spawned every 30 seconds.
+
+ speed(x) = 0.15 - x / 1,000
+damage(x) = 240  + 2⌊(960/1,000)x⌋b
+```
+
+# Group Sentry ![Group Picture](group_sentry.PNG)
+```
+Deals huge multi target damage for 60 seconds.
+The sentry is spawned every 60 seconds.
+
+cooldown(x) = 15 -  0.02gx
+  damage(x) =  4 + 0.024gx
+  pierce(x) = 18 + 0.108gx
+```
+
+# Farming Sentry ![Farming Sentry Picture](farming_sentry.png)
+Description:
+```
+Spawn a money geyser for 5 seconds. 
+The sentry is spawned every 60 seconds.
+
+crate_value(x) = 625 + 1.25x
+      speed(_) = 0.05
 ```


### PR DESCRIPTION
When viewing the README.md files for both paragon mods I noticed that they use a more C# syntax than a mathematical notation, which would be confusing to people trying to figure out what `0.1f` or `Math.FloorToInt` means. I spent about an hour or so retyping it to be a lot more mathematical while still being readable (`speed(x)` rather than `s(x)`, and `speed(_)` to infer a constant value rather than `speed()`). I also simplified much of the math (especially for the sentries) to make it more readable.

I do have a few issues however; most of the stats for the Monkey Sub Paragon's Big Missile have nothing noted for most of the stats it has, I could assume that it inherits from the previous bracket but that was not used anywhere and instead had overlaying ranges which could be mentally combined to form the stats for a paragon tier. These functions are left with `???` to symbolize that it's not known.